### PR TITLE
feat: add symbols in expandEnvVariablesWithDefaults regexp

### DIFF
--- a/load.go
+++ b/load.go
@@ -12,12 +12,12 @@ import (
 	"github.com/spf13/viper"
 )
 
-//Load load config into supported struct.
+// Load load config into supported struct.
 func (c *Config) Load(configStruct interface{}) error {
 	return c.loadInternal("", configStruct)
 }
 
-//Load load config with key into supported struct.
+// Load load config with key into supported struct.
 func (c *Config) LoadKey(key string, configStruct interface{}) error {
 	return c.loadInternal(key, configStruct)
 }
@@ -82,7 +82,7 @@ func setTagName(hook string) viper.DecoderConfigOption {
 	}
 }
 
-//StringJSONArrayOrSlicesToConfig will convert Json Encoded Strings to Maps or Slices, Used Primarily to support Slices and Maps in Environment variables
+// StringJSONArrayOrSlicesToConfig will convert Json Encoded Strings to Maps or Slices, Used Primarily to support Slices and Maps in Environment variables
 func stringJSONArrayToSlice() func(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
 	return func(
 		f reflect.Kind,
@@ -168,7 +168,7 @@ func stringJSONObjToStruct() func(f reflect.Kind, t reflect.Kind, data interface
 }
 
 func expandEnvVariablesWithDefaults() func(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
-	var configWithEnvExpand = regexp.MustCompile(`(\${([\w@.]+)(\|([\w@.]+)?)?})`)
+	var configWithEnvExpand = regexp.MustCompile(`(\${([\w@.]+)(\|([\w@.:,]+)?)?})`)
 	var exactMatchEnvExpand = regexp.MustCompile(`^` + configWithEnvExpand.String() + `$`)
 	return func(
 		f reflect.Kind,


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Improve expandEnvVariablesWithDefaults func in order to being able take default values strings that contains ':' (colon) and ',' (comma) symbols. In my case I need to add to default value host addresses in format like `host1:3333,host1:2222,host3,4477`