### PR TITLE
feat: Support `/` in expandEnvVariablesWithDefaults regex for file paths and URLs

### DIFF
--- a/load.go
+++ b/load.go
@@ -168,7 +168,7 @@ func stringJSONObjToStruct() func(f reflect.Kind, t reflect.Kind, data interface
 }
 
 func expandEnvVariablesWithDefaults() func(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
-	var configWithEnvExpand = regexp.MustCompile(`(\${([\w@.]+)(\|([\w@.:,]+)?)?})`)
+	var configWithEnvExpand = regexp.MustCompile(`(\${([\w@.]+)(\|([\w@./:,]+)?)?})`)
 	var exactMatchEnvExpand = regexp.MustCompile(`^` + configWithEnvExpand.String() + `$`)
 	return func(
 		f reflect.Kind,


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Allow `expandEnvVariablesWithDefaults` function to support default values containing the `/` (slash) character. This is necessary for handling file paths and URLs as default values, such as `/some/file/path` or `https://example.com`. Previously, default values with `/` were not correctly parsed, causing unexpected behavior.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
…
